### PR TITLE
Add OpenGraph Protocol for site preview

### DIFF
--- a/templates/default.html
+++ b/templates/default.html
@@ -7,6 +7,13 @@
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <title>ChangeMetrics - $title$</title>
         <link rel="stylesheet" type="text/css" href="/css/default.css" />
+        <meta name="twitter:card" content="summary" />
+        <meta name="twitter:site" content="change_metrics" />
+        <meta name="twitter:creator" content="change_metrics" />
+        <meta property="og:url" content="$url$" />
+        <meta property="og:title" content="$title$" />
+        <meta property="og:description" content="Monocle helps teams and individual to better organize daily duties and to detect anomalies in the way changes are produced and reviewed." />
+        <meta property="og:image" content="https://changemetrics.io/images/logo.png" />
     </head>
     <body>
         <header>


### PR DESCRIPTION
This change should enables preview card of the website using
  https://ogp.me/
See:
  https://odone.io/posts/2019-04-15-adding-twitter-cards-to-hakyll-posts.html